### PR TITLE
GitHub Actions CI: Installs GLPK to fix test execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,9 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - name: Install GLPK
+        run: |
+          sudo apt-get install -yq glpk-utils libglpk-dev glpk-doc libglpk-java libglpk40
+          sudo cp libglpk_java.* /usr/lib/
       - name: Test with Maven
         run: mvn --batch-mode --update-snapshots clean -Dtest=GlpkTest -DfailIfNoTests=false verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,6 @@ jobs:
       - name: Install GLPK
         run: |
           sudo apt-get install -yq glpk-utils libglpk-dev glpk-doc libglpk-java libglpk40
-          sudo cp libglpk_java.* /usr/lib/
+          sudo cp /usr/lib/x86_64-linux-gnu/jni/libglpk_java.* /usr/lib/
       - name: Test with Maven
         run: mvn --batch-mode --update-snapshots clean -Dtest=GlpkTest -DfailIfNoTests=false verify


### PR DESCRIPTION
@luuma27 this pull request fixes the missing GLPK Java JNIs for the GitHub Action CI (see [this Action execution](https://github.com/eMoflon/emoflon-ilp/actions/runs/6223562780/job/16890084831)).