### PR TITLE
Adds example env script + changes JDK version of dep project to JDK17

### DIFF
--- a/org.emoflon.ilp.dependencies/.settings/org.eclipse.jdt.core.prefs
+++ b/org.emoflon.ilp.dependencies/.settings/org.eclipse.jdt.core.prefs
@@ -1,9 +1,9 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=18
-org.eclipse.jdt.core.compiler.compliance=18
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=18
+org.eclipse.jdt.core.compiler.source=17

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,0 +1,5 @@
+set -e
+export LD_LIBRARY_PATH=/opt/gurobi1002/linux64/lib/:/opt/ibm/ILOG/CPLEX_Studio2211/cplex/bin/x86-64_linux/
+export GUROBI_HOME=/opt/gurobi1002/linux64/
+export GRB_LICENSE_FILE=/home/mkratz/gurobi.lic
+export PATH=$PATH:/opt/gurobi1002/linux64/bin:/opt/ibm/ILOG/CPLEX_Studio2211/cplex/bin/x86-64_linux/


### PR DESCRIPTION
With this modification, the [latest eMoflon::IBeX Eclipse build](https://github.com/eMoflon/emoflon-ibex-eclipse-build/releases/tag/v1.0.0.202309131454) can compile the project successfully.